### PR TITLE
checking if this fixes memory leak when garbage collection occurs

### DIFF
--- a/src/zstd/compress/io.cr
+++ b/src/zstd/compress/io.cr
@@ -89,5 +89,7 @@ class Zstd::Compress::IO < IO
     write_loop Lib::ZstdEndDirective::ZstdEEnd
 
     @io.close if @sync_close
+  ensure
+    @ctx.close
   end
 end

--- a/src/zstd/decompress/io.cr
+++ b/src/zstd/decompress/io.cr
@@ -93,5 +93,7 @@ class Zstd::Decompress::IO < ::IO
     @closed = true
 
     @io.close if @sync_close
+  ensure
+    @ctx.close
   end
 end


### PR DESCRIPTION
this solved my issues around crashes and memory leaks.   

didn't find good way to test but when garbage collection runs it doesn't clear mem of the external library